### PR TITLE
Grammar, spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       run: echo "${{steps.link-report.outputs.result}}"
 ```
 
-## Optional paramters:
+## Optional parameters:
 
 ### `honorRobotExclusions`
 Type: `Boolean`
@@ -43,7 +43,7 @@ https://github.com/stevenvachon/broken-link-checker#honorrobotexclusions
 ### `ignorePatterns`
 type: `String`
 Default value: `''`
-A comma separted string of matched urls to ignore. Check documentation about patterns here: https://github.com/stevenvachon/broken-link-checker#excludedkeywords
+A comma-separated string of matched urls to ignore. Check documentation about patterns here: https://github.com/stevenvachon/broken-link-checker#excludedkeywords
 
 ### `recursiveLinks`
 type: `Boolean`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
         # optional:
         honorRobotExclusions: false
         ignorePatterns: 'github,google'
-        recursiveLinks: false # Check all urls on all reachable pages (could take a while)
+        recursiveLinks: false # Check all URLs on all reachable pages (could take a while)
     - name: Get the result
       run: echo "${{steps.link-report.outputs.result}}"
 ```
@@ -43,7 +43,7 @@ https://github.com/stevenvachon/broken-link-checker#honorrobotexclusions
 ### `ignorePatterns`
 type: `String`
 Default value: `''`
-A comma-separated string of matched urls to ignore. Check documentation about patterns here: https://github.com/stevenvachon/broken-link-checker#excludedkeywords
+A comma-separated string of matched URLs to ignore. Check documentation about patterns here: https://github.com/stevenvachon/broken-link-checker#excludedkeywords
 
 ### `recursiveLinks`
 type: `Boolean`
@@ -52,7 +52,7 @@ A boolean to do a site-wide check, it will add the `blc` `-ro` param to the comm
 
 
 ## todo:
-- [ ] Create issue if broken urls are found
+- [ ] Create issue if broken URLs are found
 - [ ] Parse each broken link in report on new line
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Fail when any task exits with a non zero error;
+# Fail when any task exits with a non-zero error
 set -e
 
 NC='\033[0m' # No Color
@@ -21,7 +21,7 @@ SET_RECURSIVE=""
 
 if [ -z "$1" ] || [ "$1" == 'https://github.com/celinekurpershoek/github-actions-link-checker' ]
 then
-    echo -e "$YELLOW Warning: Running test on default url, please provide an url in you action yml.$NC"
+    echo -e "$YELLOW Warning: Running test on default url, please provide a url in your action.yml.$NC"
 fi
 
 # Set arguments for blc
@@ -55,7 +55,7 @@ fi
 # Return results
 if [ "$BROKEN_COUNT" -gt 0 ] 
 then 
-    RESULT="$BROKEN_COUNT broken url(s) found ($TOTAL_COUNT total)" 
+    RESULT="$BROKEN_COUNT broken link(s) found (out of $TOTAL_COUNT total)"
     echo -e "$RED Failed $RESULT: $NC"
     grep -E 'BROKEN' <<< "$OUTPUT" | awk '{print "[✗] " $2 "\n" }'
     echo -e "$PURPLE ============================== $NC"
@@ -63,7 +63,7 @@ then
     exit 1
 elif [ "$TOTAL_COUNT" == 0 ]
 then
-    echo -e "Did'nt find any links to check"
+    echo -e "Didn't find any links to check"
 else 
     RESULT="✓ Checked $TOTAL_COUNT link(s), no broken links found!"
     echo -e "$GREEN $RESULT $NC"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ PURPLE='\033[0;34m'
 npm i -g broken-link-checker -s
 
 echo -e "$PURPLE=== BROKEN LINK CHECKER ===$NC"
-echo -e "Running broken link checker on url: $GREEN $1 $NC"
+echo -e "Running broken link checker on URL: $GREEN $1 $NC"
 
 # Create exclude and settings strings based on configuration
 EXCLUDE="" 
@@ -21,7 +21,7 @@ SET_RECURSIVE=""
 
 if [ -z "$1" ] || [ "$1" == 'https://github.com/celinekurpershoek/github-actions-link-checker' ]
 then
-    echo -e "$YELLOW Warning: Running test on default url, please provide a url in your action.yml.$NC"
+    echo -e "$YELLOW Warning: Running test on default URL, please provide a URL in your action.yml.$NC"
 fi
 
 # Set arguments for blc
@@ -34,7 +34,7 @@ for PATTERN in ${3//,/ }; do
 done
 
 # Echo settings if any are set
-echo -e "Configuration: \n Honor robot exclusions: $GREEN$2$NC, \n Exclude urls that match: $GREEN$3$NC, \n Resursive urls: $GREEN$4$NC"
+echo -e "Configuration: \n Honor robot exclusions: $GREEN$2$NC, \n Exclude URLs that match: $GREEN$3$NC, \n Resursive URLs: $GREEN$4$NC"
 
 # Create command and remove extra quotes
 # Put result in variable to be able to iterate on it later


### PR DESCRIPTION
- [x] repair spelling errors
- [x] add hyphen to “comma-separated”
- [x] capitalize abbreviated plural “URLs” (but not where `urls` refers to code)