### PR TITLE
chore(logger): use github_output instead of set-output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,7 @@ then
     echo -e "$RED Failed $RESULT: $NC"
     grep -E 'BROKEN' <<< "$OUTPUT" | awk '{print "[✗] " $2 "\n" }'
     echo -e "$PURPLE ============================== $NC"
-    echo ::set-output name=result::"$RESULT"
+    echo "{name}={result}" >> "$GITHUB_OUTPUT"
     exit 1
 elif [ "$TOTAL_COUNT" == 0 ]
 then
@@ -67,7 +67,7 @@ then
 else 
     RESULT="✓ Checked $TOTAL_COUNT link(s), no broken links found!"
     echo -e "$GREEN $RESULT $NC"
-    echo ::set-output name=result::"$RESULT"
+    echo "{name}={result}" >> "$GITHUB_OUTPUT"
     echo -e "$PURPLE ============================== $NC"
 fi
 exit 0


### PR DESCRIPTION
As referenced in https://github.com/celinekurpershoek/link-checker/issues/20 the set-output is going to be deprecated. 
Based the example provided in github the change logs https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples